### PR TITLE
Fix: make each chapter start on a new page in PDF output

### DIFF
--- a/gitbook2pdf/libs/gitbook.css
+++ b/gitbook2pdf/libs/gitbook.css
@@ -957,3 +957,12 @@ Orginal Style from ethanschoonover.com/solarized (c) Jeremy Hull <sourdrums@gmai
 .book.color-theme-2 .book-body .page-wrapper .page-inner section.normal code .xml .hljs-cdata {
   opacity: 0.5;
 }
+
+/* Make each chapter start on a new page in the PDF output */
+section.normal + section.normal,
+section.normal + h1,
+h1 + section.normal,
+h1 + h1 {
+  page-break-before: always;
+  break-before: page;
+}


### PR DESCRIPTION
Add CSS page-break rules so that consecutive chapter sections and headers each begin on a fresh page, addressing the issue where chapters ran together without page breaks between them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced PDF and print layout formatting to ensure chapter headings and section transitions start on new pages, improving document structure and readability in exported documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->